### PR TITLE
Fix bug when there are spaces in file paths.

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function gulpCsscss(options) {
                 command = "bundle exec csscss"
             }
 
-            var child = exec(command + ' ' + file.path, function(err, stdout, stderr) {
+            var child = exec(command + ' "' + file.path + '"', function(err, stdout, stderr) {
                 if (!err) {
                     console.log("Result of running CSSCSS:");
                     console.log(stdout);


### PR DESCRIPTION
csscss would fail if there is a space in `file.path`, so I wrapped it in some `"` and it works!
