### PR TITLE
Actually use the tempFile that is created

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function gulpCsscss(options) {
                 command = "bundle exec csscss"
             }
 
-            var child = exec(command + ' "' + file.path + '"', function(err, stdout, stderr) {
+            var child = exec(command + ' "' + tempFile + '"', function(err, stdout, stderr) {
                 if (!err) {
                     console.log("Result of running CSSCSS:");
                     console.log(stdout);


### PR DESCRIPTION
As mentioned in https://github.com/morishitter/gulp-csscss/issues/4 the `csscss` command  should be called on the tmp file.
The tmp file was create correctly but wasn't used properly in the command.

Fixes https://github.com/morishitter/gulp-csscss/issues/4.